### PR TITLE
feat(coscrad-frontend): flow contributions to terms and add contributor id

### DIFF
--- a/apps/api/src/app/controllers/command/__snapshots__/command-payload-schemas.spec.ts.snap
+++ b/apps/api/src/app/controllers/command/__snapshots__/command-payload-schemas.spec.ts.snap
@@ -4202,13 +4202,6 @@ exports[`command payload schemas Command payload schema should match the snapsho
           },
         },
       },
-      "contributorId": {
-        "coscradDataType": "NON_EMPTY_STRING",
-        "description": "The ID of the knowledge keeper who contributed the term",
-        "isArray": false,
-        "isOptional": false,
-        "label": "contributor ID",
-      },
       "languageCode": {
         "complexDataType": "ENUM",
         "description": "the language of this term",

--- a/apps/api/src/app/controllers/command/__snapshots__/command-payload-schemas.spec.ts.snap
+++ b/apps/api/src/app/controllers/command/__snapshots__/command-payload-schemas.spec.ts.snap
@@ -4294,13 +4294,6 @@ exports[`command payload schemas Command payload schema should match the snapsho
           },
         },
       },
-      "contributorId": {
-        "coscradDataType": "NON_EMPTY_STRING",
-        "description": "The ID of the konwledge kepper who contributed the term",
-        "isArray": false,
-        "isOptional": true,
-        "label": "contributor ID",
-      },
       "text": {
         "coscradDataType": "NON_EMPTY_STRING",
         "description": "text for the term (in English)",

--- a/apps/api/src/app/controllers/resources/term.controller.ts
+++ b/apps/api/src/app/controllers/resources/term.controller.ts
@@ -1,9 +1,24 @@
-import { Controller, Get, Param, Request, Res, UseGuards } from '@nestjs/common';
+import {
+    Controller,
+    Get,
+    Param,
+    Request,
+    Res,
+    UseFilters,
+    UseGuards,
+    UseInterceptors,
+} from '@nestjs/common';
 import { ApiBearerAuth, ApiOkResponse, ApiParam, ApiTags } from '@nestjs/swagger';
 import { OptionalJwtAuthGuard } from '../../../authorization/optional-jwt-auth-guard';
 import { TermQueryService } from '../../../domain/services/query-services/term-query.service';
 import { ResourceType } from '../../../domain/types/ResourceType';
 import { TermViewModel } from '../../../queries/buildViewModelForResource/viewModels';
+import { QueryResponseTransformInterceptor } from '../response-mapping';
+import {
+    CoscradInternalErrorFilter,
+    CoscradInvalidUserInputFilter,
+    CoscradNotFoundFilter,
+} from '../response-mapping/CoscradExceptions/exception-filters';
 import buildViewModelPathForResourceType from '../utilities/buildIndexPathForResourceType';
 import buildByIdApiParamMetadata from './common/buildByIdApiParamMetadata';
 import sendInternalResultAsHttpResponse from './common/sendInternalResultAsHttpResponse';
@@ -11,6 +26,12 @@ import { RESOURCES_ROUTE_PREFIX } from './constants';
 
 @ApiTags(RESOURCES_ROUTE_PREFIX)
 @Controller(buildViewModelPathForResourceType(ResourceType.term))
+@UseFilters(
+    new CoscradNotFoundFilter(),
+    new CoscradInvalidUserInputFilter(),
+    new CoscradInternalErrorFilter()
+)
+@UseInterceptors(QueryResponseTransformInterceptor)
 export class TermController {
     constructor(private readonly termQueryService: TermQueryService) {}
 

--- a/apps/api/src/app/controllers/resources/term.controller.ts
+++ b/apps/api/src/app/controllers/resources/term.controller.ts
@@ -50,6 +50,8 @@ export class TermController {
     @UseGuards(OptionalJwtAuthGuard)
     @Get('')
     async fetchMany(@Request() req) {
-        return this.termQueryService.fetchMany(req.user || undefined);
+        const result = await this.termQueryService.fetchMany(req.user || undefined);
+
+        return result;
     }
 }

--- a/apps/api/src/coscrad-cli/execute-command-stream.cli-command.valid.SAMPLE.json
+++ b/apps/api/src/coscrad-cli/execute-command-stream.cli-command.valid.SAMPLE.json
@@ -7,8 +7,10 @@
                 "type": "term"
             },
             "text": "I am talking to him (language)",
-            "languageCode": "clc",
-            "contributorId": "1"
+            "languageCode": "clc"
+        },
+        "meta": {
+            "contributorIds": []
         }
     },
     {

--- a/apps/api/src/coscrad-cli/execute-command-stream.cli-command.valid.with-join.SAMPLE.json
+++ b/apps/api/src/coscrad-cli/execute-command-stream.cli-command.valid.with-join.SAMPLE.json
@@ -7,8 +7,10 @@
                 "type": "term"
             },
             "text": "I am talking to him (language)",
-            "languageCode": "clc",
-            "contributorId": "1"
+            "languageCode": "clc"
+        },
+        "meta": {
+            "contributorIds": []
         }
     },
     {

--- a/apps/api/src/domain/models/__tests__/__snapshots__/aggregate-schemas.spec.ts.snap
+++ b/apps/api/src/domain/models/__tests__/__snapshots__/aggregate-schemas.spec.ts.snap
@@ -1978,13 +1978,6 @@ exports[`Coscrad Data Schemas for aggregate root domain models the COSCRAD data 
       },
     },
   },
-  "contributorId": {
-    "coscradDataType": "NON_EMPTY_STRING",
-    "description": "reference to the contributor for this term",
-    "isArray": false,
-    "isOptional": true,
-    "label": "contributor ID",
-  },
   "id": {
     "coscradDataType": "NON_EMPTY_STRING",
     "description": "unique identifier",

--- a/apps/api/src/domain/models/term/commands/create-prompt-term/create-prompt-term.command-handler.ts
+++ b/apps/api/src/domain/models/term/commands/create-prompt-term/create-prompt-term.command-handler.ts
@@ -29,7 +29,6 @@ export class CreatePromptTermCommandHandler extends BaseCreateCommandHandler<Ter
     protected createNewInstance({
         text: promptText,
         aggregateCompositeIdentifier: { id },
-        contributorId,
     }: CreatePromptTerm): ResultOrError<Term> {
         const text = new MultilingualText({
             items: [
@@ -53,7 +52,6 @@ export class CreatePromptTermCommandHandler extends BaseCreateCommandHandler<Ter
             type: AggregateType.term,
             id,
             text,
-            contributorId,
             published: false,
             isPromptTerm: true,
             audio: new MultilingualAudio({

--- a/apps/api/src/domain/models/term/commands/create-prompt-term/create-prompt-term.command.ts
+++ b/apps/api/src/domain/models/term/commands/create-prompt-term/create-prompt-term.command.ts
@@ -29,11 +29,4 @@ export class CreatePromptTerm implements ICommandBase {
      * ```
      */
     text: string;
-
-    @NonEmptyString({
-        isOptional: true,
-        label: 'contributor ID',
-        description: 'The ID of the konwledge kepper who contributed the term',
-    })
-    contributorId?: string;
 }

--- a/apps/api/src/domain/models/term/commands/create-term/create-term.command-handler.ts
+++ b/apps/api/src/domain/models/term/commands/create-term/create-term.command-handler.ts
@@ -23,13 +23,11 @@ export class CreateTermCommandHandler extends BaseCreateCommandHandler<Term> {
         text,
         aggregateCompositeIdentifier: { id },
         languageCode,
-        contributorId,
     }: CreateTerm): ResultOrError<Term> {
         return new Term({
             type: AggregateType.term,
             id,
             text: buildMultilingualTextWithSingleItem(text, languageCode),
-            contributorId,
             // You must run `ADD_AUDIO_FOR_TERM`
             audio: new MultilingualAudio({
                 items: [],

--- a/apps/api/src/domain/models/term/commands/create-term/create-term.command.ts
+++ b/apps/api/src/domain/models/term/commands/create-term/create-term.command.ts
@@ -51,11 +51,11 @@ export class CreateTerm implements ICommandBase {
      * TODO We really want this to be part of the event metadata. We also need
      * a model for contributors.
      */
-    @NonEmptyString({
-        label: 'contributor ID',
-        description: 'The ID of the knowledge keeper who contributed the term',
-    })
-    contributorId: string;
+    // @NonEmptyString({
+    //     label: 'contributor ID',
+    //     description: 'The ID of the knowledge keeper who contributed the term',
+    // })
+    // contributorId: string;
 
     @RawDataObject({
         isOptional: true,

--- a/apps/api/src/domain/models/term/commands/create-term/create-term.command.ts
+++ b/apps/api/src/domain/models/term/commands/create-term/create-term.command.ts
@@ -47,16 +47,6 @@ export class CreateTerm implements ICommandBase {
     })
     languageCode: LanguageCode;
 
-    /**
-     * TODO We really want this to be part of the event metadata. We also need
-     * a model for contributors.
-     */
-    // @NonEmptyString({
-    //     label: 'contributor ID',
-    //     description: 'The ID of the knowledge keeper who contributed the term',
-    // })
-    // contributorId: string;
-
     @RawDataObject({
         isOptional: true,
         label: 'raw data',

--- a/apps/api/src/domain/models/term/entities/term.entity.ts
+++ b/apps/api/src/domain/models/term/entities/term.entity.ts
@@ -30,7 +30,6 @@ import validateTextFieldContextForModel from '../../shared/contextValidators/val
 import { BaseEvent } from '../../shared/events/base-event.entity';
 import { CannotReuseAudioItemError } from '../../shared/multilingual-audio/errors';
 import { MultilingualAudio } from '../../shared/multilingual-audio/multilingual-audio.entity';
-import { ContributorAndRole } from '../../song/ContributorAndRole';
 import {
     AudioAddedForTerm,
     PromptTermCreated,
@@ -68,14 +67,6 @@ export class Term extends Resource {
     })
     text: MultilingualText;
 
-    /**
-     * Note  that eventually, we will track contributions as follows. Every
-     * command can be executed `onBehalfOfContributorWithId`. If this is specified,
-     * the corresponding event will be attributed to the contributor with this ID.
-     * Otherwise, it will be attributed to the system user.
-     */
-    readonly contributions?: ContributorAndRole[];
-
     @NestedDataType(MultilingualAudio, {
         label: 'multilingual audio',
         description: 'collection of references to audio for content in available langauges',
@@ -99,19 +90,9 @@ export class Term extends Resource {
         // This should only happen in the validation context
         if (isNullOrUndefined(dto)) return;
 
-        const {
-            contributions: contributorAndRoles,
-            audio: audioDto,
-            sourceProject,
-            text,
-            isPromptTerm,
-        } = dto;
+        const { audio: audioDto, sourceProject, text, isPromptTerm } = dto;
 
         this.text = new MultilingualText(text);
-
-        this.contributions = (contributorAndRoles || []).map(
-            (contributorAndRoleDTO) => new ContributorAndRole(contributorAndRoleDTO)
-        );
 
         this.audio = isNonEmptyObject(audioDto) ? new MultilingualAudio(audioDto) : undefined;
 

--- a/apps/api/src/domain/models/term/entities/term.entity.ts
+++ b/apps/api/src/domain/models/term/entities/term.entity.ts
@@ -278,7 +278,6 @@ export class Term extends Resource {
                 aggregateCompositeIdentifier: { id },
                 text,
                 languageCode,
-                // contributorId,
             },
         } = event;
 
@@ -286,7 +285,6 @@ export class Term extends Resource {
             type: AggregateType.term,
             id,
             text: buildMultilingualTextWithSingleItem(text, languageCode),
-            // contributorId,
             // Terms are not published by default
             published: false,
             audio: new MultilingualAudio({

--- a/apps/api/src/queries/buildViewModelForResource/viewModels/base-resource.view-model.ts
+++ b/apps/api/src/queries/buildViewModelForResource/viewModels/base-resource.view-model.ts
@@ -1,5 +1,6 @@
+import { ContributorWithId } from '@coscrad/api-interfaces';
 import { NonEmptyString } from '@coscrad/data-types';
-import { isNullOrUndefined } from 'util';
+import { isNullOrUndefined } from '@coscrad/validation-constraints';
 import idEquals from '../../../domain/models/shared/functional/idEquals';
 import { CoscradContributor } from '../../../domain/models/user-management/contributor';
 import { BaseViewModel, Nameable } from './base.view-model';
@@ -15,7 +16,7 @@ export class BaseResourceViewModel extends BaseViewModel {
         description: `list of knowledge keepers who contributed this song`,
         isArray: true,
     })
-    readonly contributions: string[];
+    readonly contributions: ContributorWithId[];
 
     constructor(
         domainModel: HasViewModelId & Nameable & Accreditable,
@@ -27,7 +28,7 @@ export class BaseResourceViewModel extends BaseViewModel {
             .getContributions()
             .map(({ contributorId }) => contributors.find(idEquals(contributorId)))
             .filter((contributor) => !isNullOrUndefined(contributor))
-            .map((contributor) => contributor.fullName.toString());
+            .map(({ id, fullName }) => ({ id: id, fullName: fullName.toString() }));
 
         this.contributions = [...new Set(contributionsWithDuplicates)];
     }

--- a/apps/api/src/queries/digital-text/digital-text-queries.e2e.spec.ts
+++ b/apps/api/src/queries/digital-text/digital-text-queries.e2e.spec.ts
@@ -203,6 +203,8 @@ describe(`When querying for a digital text`, () => {
                 }
                 // no authenticated user
             ));
+
+            await app.init();
         });
 
         describe(`fetch single (by ID)`, () => {

--- a/apps/api/src/queries/term/__snapshots__/term-queries.fetch-many.e2e.spec.ts.snap
+++ b/apps/api/src/queries/term/__snapshots__/term-queries.fetch-many.e2e.spec.ts.snap
@@ -1,0 +1,400 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`when querying for a term: fetch many when the user is a project admin should allow the user to access private resources 1`] = `
+{
+  "entities": [
+    {
+      "actions": [
+        {
+          "description": "Allow a user to view (but not edit) a given resource",
+          "form": {
+            "fields": [
+              {
+                "constraints": [
+                  {
+                    "message": "must be a UUID",
+                    "name": "UUID",
+                  },
+                  {
+                    "message": "must be a defined value",
+                    "name": "defined value",
+                  },
+                ],
+                "description": "the ID of the user who will be given permission to view this resource",
+                "label": "userId",
+                "name": "userId",
+                "options": {
+                  "aggregateType": "user",
+                },
+                "type": "DYNAMIC_SELECT",
+              },
+            ],
+            "prepopulatedFields": {
+              "aggregateCompositeIdentifier": {
+                "id": "9b1deb4d-3b7d-4bad-9bdd-2b0d7b100102",
+                "type": "term",
+              },
+            },
+          },
+          "label": "Grant Read Access to User",
+          "type": "GRANT_RESOURCE_READ_ACCESS_TO_USER",
+        },
+        {
+          "description": "Make a resource visible to the public",
+          "form": {
+            "fields": [],
+            "prepopulatedFields": {
+              "aggregateCompositeIdentifier": {
+                "id": "9b1deb4d-3b7d-4bad-9bdd-2b0d7b100102",
+                "type": "term",
+              },
+            },
+          },
+          "label": "Publish Resource",
+          "type": "PUBLISH_RESOURCE",
+        },
+        {
+          "description": "Translate an existing term (typically from the language to English)",
+          "form": {
+            "fields": [
+              {
+                "constraints": [
+                  {
+                    "message": "must be a non-empty string",
+                    "name": "non-empty string",
+                  },
+                  {
+                    "message": "must be a defined value",
+                    "name": "defined value",
+                  },
+                ],
+                "description": "translation for the given term",
+                "label": "translation",
+                "name": "translation",
+                "type": "TEXT_FIELD",
+              },
+              {
+                "constraints": [
+                  {
+                    "message": "Must be a valid \${propertyLabel}",
+                    "name": "IS_ENUM",
+                  },
+                  {
+                    "message": "Required",
+                    "name": "defined value",
+                  },
+                ],
+                "description": "language in which you are translating the term (typically English)",
+                "label": "language code",
+                "name": "languageCode",
+                "options": [
+                  {
+                    "display": "Chilcotin",
+                    "value": "clc",
+                  },
+                  {
+                    "display": "Haida",
+                    "value": "hai",
+                  },
+                  {
+                    "display": "English",
+                    "value": "en",
+                  },
+                  {
+                    "display": "French",
+                    "value": "fra",
+                  },
+                  {
+                    "display": "Chinook",
+                    "value": "chn",
+                  },
+                  {
+                    "display": "Zapotec",
+                    "value": "zap",
+                  },
+                  {
+                    "display": "Spanish",
+                    "value": "spa",
+                  },
+                ],
+                "type": "STATIC_SELECT",
+              },
+            ],
+            "prepopulatedFields": {
+              "aggregateCompositeIdentifier": {
+                "id": "9b1deb4d-3b7d-4bad-9bdd-2b0d7b100102",
+                "type": "term",
+              },
+            },
+          },
+          "label": "Translate Term",
+          "type": "TRANSLATE_TERM",
+        },
+      ],
+      "contributions": [],
+      "id": "9b1deb4d-3b7d-4bad-9bdd-2b0d7b100102",
+      "name": {
+        "items": [
+          {
+            "languageCode": "hai",
+            "role": "original",
+            "text": "Term (in the language)",
+          },
+          {
+            "languageCode": "en",
+            "role": "free translation",
+            "text": "Term (in English)",
+          },
+        ],
+      },
+      "tags": [],
+    },
+    {
+      "actions": [
+        {
+          "description": "Allow a user to view (but not edit) a given resource",
+          "form": {
+            "fields": [
+              {
+                "constraints": [
+                  {
+                    "message": "must be a UUID",
+                    "name": "UUID",
+                  },
+                  {
+                    "message": "must be a defined value",
+                    "name": "defined value",
+                  },
+                ],
+                "description": "the ID of the user who will be given permission to view this resource",
+                "label": "userId",
+                "name": "userId",
+                "options": {
+                  "aggregateType": "user",
+                },
+                "type": "DYNAMIC_SELECT",
+              },
+            ],
+            "prepopulatedFields": {
+              "aggregateCompositeIdentifier": {
+                "id": "9b1deb4d-3b7d-4bad-9bdd-2b0d7b100103",
+                "type": "term",
+              },
+            },
+          },
+          "label": "Grant Read Access to User",
+          "type": "GRANT_RESOURCE_READ_ACCESS_TO_USER",
+        },
+        {
+          "description": "Make a resource visible to the public",
+          "form": {
+            "fields": [],
+            "prepopulatedFields": {
+              "aggregateCompositeIdentifier": {
+                "id": "9b1deb4d-3b7d-4bad-9bdd-2b0d7b100103",
+                "type": "term",
+              },
+            },
+          },
+          "label": "Publish Resource",
+          "type": "PUBLISH_RESOURCE",
+        },
+        {
+          "description": "Translate an existing term (typically from the language to English)",
+          "form": {
+            "fields": [
+              {
+                "constraints": [
+                  {
+                    "message": "must be a non-empty string",
+                    "name": "non-empty string",
+                  },
+                  {
+                    "message": "must be a defined value",
+                    "name": "defined value",
+                  },
+                ],
+                "description": "translation for the given term",
+                "label": "translation",
+                "name": "translation",
+                "type": "TEXT_FIELD",
+              },
+              {
+                "constraints": [
+                  {
+                    "message": "Must be a valid \${propertyLabel}",
+                    "name": "IS_ENUM",
+                  },
+                  {
+                    "message": "Required",
+                    "name": "defined value",
+                  },
+                ],
+                "description": "language in which you are translating the term (typically English)",
+                "label": "language code",
+                "name": "languageCode",
+                "options": [
+                  {
+                    "display": "Chilcotin",
+                    "value": "clc",
+                  },
+                  {
+                    "display": "Haida",
+                    "value": "hai",
+                  },
+                  {
+                    "display": "English",
+                    "value": "en",
+                  },
+                  {
+                    "display": "French",
+                    "value": "fra",
+                  },
+                  {
+                    "display": "Chinook",
+                    "value": "chn",
+                  },
+                  {
+                    "display": "Zapotec",
+                    "value": "zap",
+                  },
+                  {
+                    "display": "Spanish",
+                    "value": "spa",
+                  },
+                ],
+                "type": "STATIC_SELECT",
+              },
+            ],
+            "prepopulatedFields": {
+              "aggregateCompositeIdentifier": {
+                "id": "9b1deb4d-3b7d-4bad-9bdd-2b0d7b100103",
+                "type": "term",
+              },
+            },
+          },
+          "label": "Translate Term",
+          "type": "TRANSLATE_TERM",
+        },
+      ],
+      "contributions": [],
+      "id": "9b1deb4d-3b7d-4bad-9bdd-2b0d7b100103",
+      "name": {
+        "items": [
+          {
+            "languageCode": "hai",
+            "role": "original",
+            "text": "Term (in the language)",
+          },
+          {
+            "languageCode": "en",
+            "role": "free translation",
+            "text": "Term (in English)",
+          },
+        ],
+      },
+      "tags": [],
+    },
+  ],
+  "indexScopedActions": [
+    {
+      "description": "Create a new term in the language",
+      "form": {
+        "fields": [
+          {
+            "constraints": [
+              {
+                "message": "must be a non-empty string",
+                "name": "non-empty string",
+              },
+              {
+                "message": "must be a defined value",
+                "name": "defined value",
+              },
+            ],
+            "description": "text for the term (in the language)",
+            "label": "text",
+            "name": "text",
+            "type": "TEXT_FIELD",
+          },
+          {
+            "constraints": [
+              {
+                "message": "Must be a valid \${propertyLabel}",
+                "name": "IS_ENUM",
+              },
+              {
+                "message": "Required",
+                "name": "defined value",
+              },
+            ],
+            "description": "the language of this term",
+            "label": "language code",
+            "name": "languageCode",
+            "options": [
+              {
+                "display": "Chilcotin",
+                "value": "clc",
+              },
+              {
+                "display": "Haida",
+                "value": "hai",
+              },
+              {
+                "display": "English",
+                "value": "en",
+              },
+              {
+                "display": "French",
+                "value": "fra",
+              },
+              {
+                "display": "Chinook",
+                "value": "chn",
+              },
+              {
+                "display": "Zapotec",
+                "value": "zap",
+              },
+              {
+                "display": "Spanish",
+                "value": "spa",
+              },
+            ],
+            "type": "STATIC_SELECT",
+          },
+        ],
+        "prepopulatedFields": {},
+      },
+      "label": "Create Term",
+      "type": "CREATE_TERM",
+    },
+    {
+      "description": "Create a new Prompt Term in the language",
+      "form": {
+        "fields": [
+          {
+            "constraints": [
+              {
+                "message": "must be a non-empty string",
+                "name": "non-empty string",
+              },
+              {
+                "message": "must be a defined value",
+                "name": "defined value",
+              },
+            ],
+            "description": "text for the term (in English)",
+            "label": "text",
+            "name": "text",
+            "type": "TEXT_FIELD",
+          },
+        ],
+        "prepopulatedFields": {},
+      },
+      "label": "Create Prompt Term",
+      "type": "CREATE_PROMPT_TERM",
+    },
+  ],
+}
+`;

--- a/apps/api/src/queries/term/term-queries.fetch-by-id.e2e.spec.ts
+++ b/apps/api/src/queries/term/term-queries.fetch-by-id.e2e.spec.ts
@@ -1,0 +1,180 @@
+import { AggregateType, LanguageCode, ResourceType } from '@coscrad/api-interfaces';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import httpStatusCodes from '../../app/constants/httpStatusCodes';
+import setUpIntegrationTest from '../../app/controllers/__tests__/setUpIntegrationTest';
+import buildDummyUuid from '../../domain/models/__tests__/utilities/buildDummyUuid';
+import { TermCreated, TermTranslated } from '../../domain/models/term/commands';
+import { Term } from '../../domain/models/term/entities/term.entity';
+import { AggregateId } from '../../domain/types/AggregateId';
+import { ArangoDatabaseProvider } from '../../persistence/database/database.provider';
+import TestRepositoryProvider from '../../persistence/repositories/__tests__/TestRepositoryProvider';
+import generateDatabaseNameForTestSuite from '../../persistence/repositories/__tests__/generateDatabaseNameForTestSuite';
+import { ArangoEventRepository } from '../../persistence/repositories/arango-event-repository';
+import { TestEventStream } from '../../test-data/events';
+import { DynamicDataTypeFinderService } from '../../validation';
+
+// Set up endpoints: index endpoint, id endpoint
+const indexEndpoint = `/resources/terms`;
+
+const buildDetailEndpoint = (id: AggregateId) => `${indexEndpoint}/${id}`;
+
+// Set up test data (use event sourcing to set up state)
+const termText = `Term (in the language)`;
+
+const originalLanguage = LanguageCode.Haida;
+
+const termTranslation = `Term (in English)`;
+
+const translationLanguage = LanguageCode.English;
+
+const termId = buildDummyUuid(1);
+
+const termCreated = new TestEventStream().andThen<TermCreated>({
+    type: 'TERM_CREATED',
+    payload: {
+        text: termText,
+        languageCode: originalLanguage,
+    },
+});
+
+const termTranslated = termCreated.andThen<TermTranslated>({
+    type: 'TERM_TRANSLATED',
+    payload: {
+        translation: termTranslation,
+        languageCode: translationLanguage,
+    },
+});
+
+// const promptTermId = buildDummyUuid(2)
+
+describe(`when querying for a term: fetch by Id`, () => {
+    const testDatabaseName = generateDatabaseNameForTestSuite();
+
+    let app: INestApplication;
+
+    let testRepositoryProvider: TestRepositoryProvider;
+
+    let databaseProvider: ArangoDatabaseProvider;
+
+    beforeEach(async () => {
+        await testRepositoryProvider.testSetup();
+    });
+
+    afterAll(async () => {
+        await app.close();
+
+        databaseProvider.close();
+    });
+
+    describe(`when the user is unauthenticated`, () => {
+        beforeAll(async () => {
+            ({ app, testRepositoryProvider, databaseProvider } = await setUpIntegrationTest(
+                {
+                    ARANGO_DB_NAME: testDatabaseName,
+                }
+                // no authenticated user
+            ));
+
+            await app.get(DynamicDataTypeFinderService).bootstrapDynamicTypes();
+        });
+
+        describe(`when there is a term with the given Id`, () => {
+            describe(`when a term is published`, () => {
+                beforeEach(async () => {
+                    const eventHistoryForTerm = termTranslated.as({
+                        type: AggregateType.term,
+                        id: termId,
+                    });
+                    // TODO: we need to check that contributors come through
+
+                    await app.get(ArangoEventRepository).appendEvents(eventHistoryForTerm);
+
+                    const term = Term.fromEventHistory(eventHistoryForTerm, termId) as Term;
+
+                    await testRepositoryProvider.forResource(ResourceType.term).create(term);
+                });
+
+                it('should return the expected result', async () => {
+                    const res = await request(app.getHttpServer()).get(buildDetailEndpoint(termId));
+
+                    expect(res.status).toBe(httpStatusCodes.ok);
+
+                    // TODO: Check the state of the response in detail
+                });
+            });
+
+            describe(`when a term is unpublished`, () => {
+                // We pretend the resource does not exist when the user
+                // does not have access to this term
+                it.todo(`should return not found (404)`);
+            });
+        });
+
+        describe(`when there is no term with the given Id`, () => {
+            it.todo(`should return not found (404)`);
+        });
+    });
+
+    describe(`when the user is authenticated`, () => {
+        describe(`when the user is a coscrad admin`, () => {
+            describe(`when there is a term with the given Id`, () => {
+                describe(`when the term is published`, () => {
+                    it.todo(`should return the expected result`);
+                });
+
+                describe(`when the term is not published`, () => {
+                    it.todo(`should return the expected result`);
+                });
+
+                describe(`when the term is unpublished but and the user has explicit access`, () => {
+                    it.todo(`should return the expected result`);
+                });
+            });
+
+            describe(`when there is no term with the given Id`, () => {
+                it.todo(`should return not found (404)`);
+            });
+        });
+
+        describe(`when the user is a project admin`, () => {
+            describe(`when there is a term with the given Id`, () => {
+                describe(`when the term is published`, () => {
+                    it.todo(`should return the expected result`);
+                });
+
+                describe(`when the term is not published`, () => {
+                    it.todo(`should return the expected result`);
+                });
+
+                describe(`when the term is unpublished but and the user has explicit access`, () => {
+                    it.todo(`should return the expected result`);
+                });
+            });
+
+            describe(`when there is no term with the given Id`, () => {
+                it.todo(`should return not found (404)`);
+            });
+        });
+
+        describe(`when the user is an ordinary authenticated user`, () => {
+            describe(`when there is a term with the given Id`, () => {
+                describe(`when the term is published`, () => {
+                    it.todo(`should return the expected result`);
+                });
+
+                describe(`when the term is not published and the user does not have access`, () => {
+                    it.todo(`should return the expected result`);
+                });
+
+                describe(`when the term is unpublished but the user has access`, () => {
+                    it.todo(`should return the expected result`);
+                });
+            });
+
+            describe(`when there is no term with the given Id`, () => {
+                it.todo(`should return not found (404)`);
+            });
+        });
+    });
+});

--- a/apps/api/src/queries/term/term-queries.fetch-many.e2e.spec.ts
+++ b/apps/api/src/queries/term/term-queries.fetch-many.e2e.spec.ts
@@ -1,0 +1,162 @@
+import { CoscradUserRole, LanguageCode, ResourceType } from '@coscrad/api-interfaces';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import httpStatusCodes from '../../app/constants/httpStatusCodes';
+import setUpIntegrationTest from '../../app/controllers/__tests__/setUpIntegrationTest';
+import buildDummyUuid from '../../domain/models/__tests__/utilities/buildDummyUuid';
+import { ResourceReadAccessGrantedToUser } from '../../domain/models/shared/common-commands';
+import { ResourcePublished } from '../../domain/models/shared/common-commands/publish-resource/resource-published.event';
+import { TagCreated } from '../../domain/models/tag/commands/create-tag/tag-created.event';
+import { ResourceOrNoteTagged } from '../../domain/models/tag/commands/tag-resource-or-note/resource-or-note-tagged.event';
+import { TermCreated, TermTranslated } from '../../domain/models/term/commands';
+import { CoscradUserGroup } from '../../domain/models/user-management/group/entities/coscrad-user-group.entity';
+import { CoscradUserWithGroups } from '../../domain/models/user-management/user/entities/user/coscrad-user-with-groups';
+import { CoscradUser } from '../../domain/models/user-management/user/entities/user/coscrad-user.entity';
+import { ArangoDatabaseProvider } from '../../persistence/database/database.provider';
+import TestRepositoryProvider from '../../persistence/repositories/__tests__/TestRepositoryProvider';
+import generateDatabaseNameForTestSuite from '../../persistence/repositories/__tests__/generateDatabaseNameForTestSuite';
+import { ArangoEventRepository } from '../../persistence/repositories/arango-event-repository';
+import buildTestDataInFlatFormat from '../../test-data/buildTestDataInFlatFormat';
+import { TestEventStream } from '../../test-data/events';
+
+const indexEndpoint = `/resources/terms`;
+
+// We require an existing user for ACL tests
+const dummyQueryUserId = buildDummyUuid(4);
+
+const { user: users, userGroup: userGroups } = buildTestDataInFlatFormat();
+
+const dummyUser = (users as CoscradUser[])[0].clone({
+    authProviderUserId: `auth0|${dummyQueryUserId}`,
+    id: dummyQueryUserId,
+    roles: [CoscradUserRole.viewer],
+});
+
+const dummyGroup = (userGroups as CoscradUserGroup[])[0].clone({ userIds: [dummyUser.id] });
+
+const dummyUserWithGroups = new CoscradUserWithGroups(dummyUser, [dummyGroup]);
+
+// Set up test data (use event sourcing to set up state)
+const termText = `Term (in the language)`;
+
+const originalLanguage = LanguageCode.Haida;
+
+const termTranslation = `Term (in English)`;
+
+const translationLanguage = LanguageCode.English;
+
+const termId = buildDummyUuid(101);
+
+const termIdUnpublishedNoUserAccessId = buildDummyUuid(102);
+
+const termIdUnpublishedWithUserAccessId = buildDummyUuid(103);
+
+const termCreated = new TestEventStream().andThen<TermCreated>({
+    type: 'TERM_CREATED',
+    payload: {
+        text: termText,
+        languageCode: originalLanguage,
+    },
+});
+
+const termTranslated = termCreated.andThen<TermTranslated>({
+    type: 'TERM_TRANSLATED',
+    payload: {
+        translation: termTranslation,
+        languageCode: translationLanguage,
+    },
+});
+
+const termPrivateThatUserCanAccess = termTranslated.andThen<ResourceReadAccessGrantedToUser>({
+    type: 'RESOURCE_READ_ACCESS_GRANTED_TO_USER',
+    payload: {
+        userId: dummyQueryUserId,
+    },
+});
+
+const termPublished = termTranslated.andThen<ResourcePublished>({
+    type: 'RESOURCE_PUBLISHED',
+});
+
+const labelForTagForPrivateTerm = 'animals';
+
+const termPrivateForTagging = new TestEventStream()
+    .andThen<TagCreated>({
+        type: 'TAG_CREATED',
+        payload: {
+            label: labelForTagForPrivateTerm,
+        },
+    })
+    .andThen<ResourceOrNoteTagged>({
+        type: 'RESOURCE_OR_NOTE_TAGGED',
+        payload: {
+            taggedMemberCompositeIdentifier: {
+                type: ResourceType.term,
+                id: termIdUnpublishedWithUserAccessId,
+            },
+        },
+    });
+
+// const promptTermId = buildDummyUuid(2)
+
+describe(`when querying for a term: fetch many`, () => {
+    const testDatabaseName = generateDatabaseNameForTestSuite();
+
+    let app: INestApplication;
+
+    let testRepositoryProvider: TestRepositoryProvider;
+
+    let databaseProvider: ArangoDatabaseProvider;
+
+    beforeEach(async () => {
+        await testRepositoryProvider.testSetup();
+    });
+
+    afterAll(async () => {
+        await app.close();
+
+        databaseProvider.close();
+    });
+
+    const eventHistoryForMany = [
+        ...termPublished.as({ id: termId }),
+        ...termTranslated.as({ id: termIdUnpublishedNoUserAccessId }),
+        ...termPrivateThatUserCanAccess.as({
+            id: termIdUnpublishedWithUserAccessId,
+        }),
+        ...termPrivateForTagging.as({ id: buildDummyUuid(555) }),
+    ];
+
+    eventHistoryForMany.forEach((event) => {
+        const {
+            payload: { aggregateCompositeIdentifier },
+        } = event;
+
+        console.log({ aggregateCompositeIdentifier });
+    });
+
+    describe(`when the user is unauthenticated`, () => {
+        beforeAll(async () => {
+            ({ app, testRepositoryProvider, databaseProvider } = await setUpIntegrationTest(
+                {
+                    ARANGO_DB_NAME: testDatabaseName,
+                }
+                // no authenticated user
+            ));
+
+            await app.init();
+        });
+
+        it(`should only return published terms`, async () => {
+            await app.get(ArangoEventRepository).appendEvents(eventHistoryForMany);
+
+            const res = await request(app.getHttpServer()).get(indexEndpoint);
+
+            expect(res.status).toBe(httpStatusCodes.ok);
+
+            const { body } = res;
+
+            console.log({ body });
+        });
+    });
+});

--- a/apps/api/src/queries/term/term-queries.fetch-many.e2e.spec.ts
+++ b/apps/api/src/queries/term/term-queries.fetch-many.e2e.spec.ts
@@ -3,7 +3,6 @@ import {
     CoscradUserRole,
     HttpStatusCode,
     LanguageCode,
-    ResourceType,
 } from '@coscrad/api-interfaces';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
@@ -12,8 +11,6 @@ import setUpIntegrationTest from '../../app/controllers/__tests__/setUpIntegrati
 import buildDummyUuid from '../../domain/models/__tests__/utilities/buildDummyUuid';
 import { ResourceReadAccessGrantedToUser } from '../../domain/models/shared/common-commands';
 import { ResourcePublished } from '../../domain/models/shared/common-commands/publish-resource/resource-published.event';
-import { TagCreated } from '../../domain/models/tag/commands/create-tag/tag-created.event';
-import { ResourceOrNoteTagged } from '../../domain/models/tag/commands/tag-resource-or-note/resource-or-note-tagged.event';
 import { TermCreated, TermTranslated } from '../../domain/models/term/commands';
 import { CoscradUserGroup } from '../../domain/models/user-management/group/entities/coscrad-user-group.entity';
 import { CoscradUserWithGroups } from '../../domain/models/user-management/user/entities/user/coscrad-user-with-groups';
@@ -85,25 +82,6 @@ const termPublished = termTranslated.andThen<ResourcePublished>({
     type: 'RESOURCE_PUBLISHED',
 });
 
-const labelForTagForPrivateTerm = 'animals';
-
-const termPrivateForTagging = new TestEventStream()
-    .andThen<TagCreated>({
-        type: 'TAG_CREATED',
-        payload: {
-            label: labelForTagForPrivateTerm,
-        },
-    })
-    .andThen<ResourceOrNoteTagged>({
-        type: 'RESOURCE_OR_NOTE_TAGGED',
-        payload: {
-            taggedMemberCompositeIdentifier: {
-                type: ResourceType.term,
-                id: termIdUnpublishedWithUserAccessId,
-            },
-        },
-    });
-
 // const promptTermId = buildDummyUuid(2)
 
 describe(`when querying for a term: fetch many`, () => {
@@ -131,7 +109,6 @@ describe(`when querying for a term: fetch many`, () => {
             id: termIdUnpublishedWithUserAccessId,
             type: AggregateType.term,
         }),
-        // ...termPrivateForTagging.as({ id: buildDummyUuid(555), type: AggregateType.term }),
     ];
 
     const eventHistoryForManyWithPublishedTerm = [

--- a/apps/api/src/test-data/buildTermTestData.ts
+++ b/apps/api/src/test-data/buildTermTestData.ts
@@ -124,7 +124,6 @@ const [bilingualTerm1Events, bilingualTerm2Events] = ['1', '2'].map((id) =>
             type: PROMPT_TERM_CREATED,
             payload: {
                 text: `Engl-term-${id}`,
-                contributorId: 'John Doe',
             },
         })
         .andThen<TermElicitedFromPrompt>({

--- a/apps/api/src/test-data/buildTermTestData.ts
+++ b/apps/api/src/test-data/buildTermTestData.ts
@@ -36,7 +36,6 @@ const iAmSingingEvents = new TestEventStream()
         type: TERM_CREATED,
         payload: {
             text: 'I am singing (lang)',
-            contributorId: 'Sarah Smith',
             languageCode: LanguageCode.Chilcotin,
         },
     })
@@ -55,7 +54,6 @@ const youAreSingingEvents = new TestEventStream()
         type: TERM_CREATED,
         payload: {
             text: 'You are singing (lang)',
-            contributorId: 'Sarah Smith',
             languageCode: LanguageCode.Chilcotin,
         },
     })
@@ -73,7 +71,6 @@ const sheIsSingingEvents = new TestEventStream()
         type: TERM_CREATED,
         payload: {
             text: 'She is singing (lang)',
-            contributorId: 'Sarah Smith',
             languageCode: LanguageCode.Chilcotin,
         },
     })
@@ -91,7 +88,6 @@ const iAmNotSingingEvents = new TestEventStream()
         type: TERM_CREATED,
         payload: {
             text: 'I am not singing (lang)',
-            contributorId: 'Sarah Smith',
             languageCode: LanguageCode.Chilcotin,
         },
     })
@@ -110,7 +106,6 @@ const youAreNotSingingEvents = new TestEventStream()
         type: TERM_CREATED,
         payload: {
             text: 'You are not singing (lang)',
-            contributorId: 'Sarah Smith',
             languageCode: LanguageCode.Chilcotin,
         },
     })
@@ -146,7 +141,6 @@ const chilcotinOnlyTermEvents = new TestEventStream().andThen<TermCreated>({
     type: TERM_CREATED,
     payload: {
         text: 'Chil-term-no-english',
-        contributorId: 'Jane Deer',
     },
 });
 // not published
@@ -156,7 +150,6 @@ const englishOnlyTermEvents = new TestEventStream()
         type: TERM_CREATED,
         payload: {
             text: 'My Secret Term',
-            contributorId: 'This prop will be removed soon',
         },
     })
     .andThen<ResourceReadAccessGrantedToUser>({

--- a/apps/api/src/test-data/commands/build-term-test-command-fsas.ts
+++ b/apps/api/src/test-data/commands/build-term-test-command-fsas.ts
@@ -27,7 +27,6 @@ const createTerm: CommandFSA<CreateTerm> = {
         },
         text: 'I am talking to him (language)',
         languageCode: LanguageCode.Chilcotin,
-        contributorId: `1`,
     },
 };
 

--- a/apps/api/src/test-data/events/test-event-stream.ts
+++ b/apps/api/src/test-data/events/test-event-stream.ts
@@ -360,8 +360,6 @@ const buildTermCreated = (
         },
         text: 'he is jumping',
         languageCode: LanguageCode.Haida,
-        // TODO remove this
-        contributorId: '1',
     };
 
     return new TermCreated(

--- a/apps/coscrad-frontend/src/app/bootstrap-index-to-detail-flow-routes.tsx
+++ b/apps/coscrad-frontend/src/app/bootstrap-index-to-detail-flow-routes.tsx
@@ -32,11 +32,6 @@ export const bootstrapIndexToDetailFlowRoutes = ({
                 (route && `Resources/${route}`) ||
                 routes.resources.ofType(categorizableType as ResourceType).index;
 
-            console.log({
-                categorizableType,
-                resolvedRoute,
-            });
-
             return {
                 ...acc,
                 [categorizableType]:

--- a/apps/coscrad-frontend/src/components/resources/songs/song-index.presenter.tsx
+++ b/apps/coscrad-frontend/src/components/resources/songs/song-index.presenter.tsx
@@ -10,6 +10,7 @@ import { Matchers } from '../../../utils/generic-components/presenters/tables/ge
 import { CellRenderersDefinition } from '../../../utils/generic-components/presenters/tables/generic-index-table-presenter/types/cell-renderers-definition';
 import { doesSomeMultilingualTextItemInclude } from '../utils/query-matchers';
 import { renderAggregateIdCell } from '../utils/render-aggregate-id-cell';
+import { renderContributionsTextCell } from '../utils/render-contributions-text-cell';
 import { renderMultilingualTextCell } from '../utils/render-multilingual-text-cell';
 
 export const SongIndexPresenter = (songsIndexResult: SongIndexState) => {
@@ -29,7 +30,8 @@ export const SongIndexPresenter = (songsIndexResult: SongIndexState) => {
         name: ({ name }: ISongViewModel) => renderMultilingualTextCell(name, defaultLanguageCode),
         audioURL: ({ audioURL }: ISongViewModel) =>
             isNullOrUndefined(audioURL) ? <LinkOff /> : <AudioClipPlayer audioUrl={audioURL} />,
-        contributions: ({ contributions }) => (contributions || []).join(`, `),
+        contributions: ({ contributions }: ISongViewModel) =>
+            renderContributionsTextCell(contributions),
     };
 
     const matchers: Matchers<ISongViewModel> = {

--- a/apps/coscrad-frontend/src/components/resources/terms/term-detail.full-view.presenter.tsx
+++ b/apps/coscrad-frontend/src/components/resources/terms/term-detail.full-view.presenter.tsx
@@ -25,7 +25,6 @@ export const TermDetailFullViewPresenter = ({
             <Box
                 data-testid={buildDataAttributeForAggregateDetailComponent(AggregateType.term, id)}
             />
-            {/* <SingleOptionalPropertyPresenter display="Contributor" value={contributions} /> */}
             <Box id="media-player">
                 <AudioClipPlayer audioUrl={audioURL} />
             </Box>

--- a/apps/coscrad-frontend/src/components/resources/terms/term-detail.full-view.presenter.tsx
+++ b/apps/coscrad-frontend/src/components/resources/terms/term-detail.full-view.presenter.tsx
@@ -6,10 +6,7 @@ import {
 } from '@coscrad/api-interfaces';
 import { AudioClipPlayer } from '@coscrad/media-player';
 import { Box } from '@mui/material';
-import {
-    ResourceDetailFullViewPresenter,
-    SingleOptionalPropertyPresenter,
-} from '../../../utils/generic-components/';
+import { ResourceDetailFullViewPresenter } from '../../../utils/generic-components/';
 import { buildDataAttributeForAggregateDetailComponent } from '../../../utils/generic-components/presenters/detail-views/build-data-attribute-for-aggregate-detail-component';
 
 export const TermDetailFullViewPresenter = ({
@@ -23,12 +20,12 @@ export const TermDetailFullViewPresenter = ({
             name={name}
             id={id}
             type={ResourceType.term}
-            contributions={[]}
+            contributions={contributions}
         >
             <Box
                 data-testid={buildDataAttributeForAggregateDetailComponent(AggregateType.term, id)}
             />
-            <SingleOptionalPropertyPresenter display="Contributor" value={contributions} />
+            {/* <SingleOptionalPropertyPresenter display="Contributor" value={contributions} /> */}
             <Box id="media-player">
                 <AudioClipPlayer audioUrl={audioURL} />
             </Box>

--- a/apps/coscrad-frontend/src/components/resources/terms/term-index.presenter.tsx
+++ b/apps/coscrad-frontend/src/components/resources/terms/term-index.presenter.tsx
@@ -10,6 +10,7 @@ import { Matchers } from '../../../utils/generic-components/presenters/tables/ge
 import { CellRenderersDefinition } from '../../../utils/generic-components/presenters/tables/generic-index-table-presenter/types/cell-renderers-definition';
 import { doesSomeMultilingualTextItemInclude } from '../utils/query-matchers';
 import { renderAggregateIdCell } from '../utils/render-aggregate-id-cell';
+import { renderContributionsTextCell } from '../utils/render-contributions-text-cell';
 import { renderMultilingualTextCell } from '../utils/render-multilingual-text-cell';
 
 export const TermIndexPresenter = (termsIndexResult: TermIndexState) => {
@@ -35,7 +36,8 @@ export const TermIndexPresenter = (termsIndexResult: TermIndexState) => {
             ) : (
                 <AudioClipPlayer audioUrl={audioURL} />
             ),
-        contributions: ({ contributions }: ITermViewModel) => contributions.join(', '),
+        contributions: ({ contributions }: ITermViewModel) =>
+            renderContributionsTextCell(contributions),
     };
 
     const matchers: Matchers<ITermViewModel> = {

--- a/apps/coscrad-frontend/src/components/resources/utils/render-contributions-text-cell.tsx
+++ b/apps/coscrad-frontend/src/components/resources/utils/render-contributions-text-cell.tsx
@@ -1,0 +1,7 @@
+import { ContributorWithId } from '@coscrad/api-interfaces';
+
+export const renderContributionsTextCell = (contributions: ContributorWithId[]): JSX.Element => {
+    const contributors = contributions.map(({ fullName }) => fullName);
+
+    return <span>{contributors.join(', ')}</span>;
+};

--- a/apps/coscrad-frontend/src/components/resources/videos/video-index.presenter.tsx
+++ b/apps/coscrad-frontend/src/components/resources/videos/video-index.presenter.tsx
@@ -17,6 +17,7 @@ import {
 import { CellRenderersDefinition } from '../../../utils/generic-components/presenters/tables/generic-index-table-presenter/types/cell-renderers-definition';
 import { renderAggregateIdCell } from '../utils/render-aggregate-id-cell';
 import { renderMultilingualTextItem } from '../utils/render-cell-for-single-language';
+import { renderContributionsTextCell } from '../utils/render-contributions-text-cell';
 import { renderMediaLengthInSeconds } from '../utils/render-media-length-in-seconds-cell';
 
 const inLanguage = (languageCodeToFind: LanguageCode, multilingualText: IMultilingualText) =>
@@ -58,7 +59,8 @@ export const VideoIndexPresenter = ({ entities: videos }: VideoIndexState): JSX.
         name: ({ name }) => (isNullOrUndefined(name) ? null : renderMultilingualTextItem(name)),
         nameEnglish: ({ nameEnglish }) =>
             isNullOrUndefined(nameEnglish) ? null : renderMultilingualTextItem(nameEnglish),
-        contributions: ({ contributions }) => contributions.join(', '),
+        contributions: ({ contributions }: VideoTableRow) =>
+            renderContributionsTextCell(contributions),
     };
 
     // We may want to bring in the full MultilingualText class to the front-end and put this behaviour on a method instead

--- a/apps/coscrad-frontend/src/utils/generic-components/presenters/detail-views/resource-detail-full-view-presenter.tsx
+++ b/apps/coscrad-frontend/src/utils/generic-components/presenters/detail-views/resource-detail-full-view-presenter.tsx
@@ -1,4 +1,4 @@
-import { IMultilingualText, ResourceType } from '@coscrad/api-interfaces';
+import { ContributorWithId, IMultilingualText, ResourceType } from '@coscrad/api-interfaces';
 import { ListRounded, Person } from '@mui/icons-material';
 import {
     Box,
@@ -16,31 +16,38 @@ import { buildDataAttributeForAggregateDetailComponent } from './build-data-attr
 import { ResourceDetailPresenterHeader } from './resource-detail-presenter-header';
 import { ResourcePreviewIconFactory } from './resource-preview-icon';
 
-interface ContributionPresenterProps {
-    contributor: string;
-}
-
-const ContributionsPresenter = ({ contributions }: { contributions: string[] }): JSX.Element => (
-    <>
-        {contributions.map((contributor, index) => (
-            <Box>
-                <ContributionPresenter contributor={contributor} key={contributor + index} />
+const ContributionsPresenter = ({
+    contributions,
+}: {
+    contributions: ContributorWithId[];
+}): JSX.Element => (
+    <List>
+        {contributions.map((contribution) => (
+            <ListItem
+                disableGutters
+                style={{ borderBottom: '1px solid #ccc' }}
+                key={`${contribution.fullName}-${contribution.id}`}
+                data-testid={`${contribution.id}`}
+            >
+                <ContributionPresenter contributor={contribution} />
                 <Divider />
-            </Box>
+            </ListItem>
         ))}
-    </>
+    </List>
 );
 
-const ContributionPresenter = ({ contributor }: ContributionPresenterProps) => {
+interface ContributionPresenterProps {
+    contributor: ContributorWithId;
+}
+
+const ContributionPresenter = ({ contributor: { fullName } }: ContributionPresenterProps) => {
     return (
-        <List>
-            <ListItem disableGutters disablePadding>
-                <ListItemIcon>
-                    <Person color="secondary" />
-                </ListItemIcon>
-                <Typography variant="body1">{contributor}</Typography>
-            </ListItem>
-        </List>
+        <>
+            <ListItemIcon>
+                <Person color="secondary" />
+            </ListItemIcon>
+            <Typography variant="body1">{fullName}</Typography>
+        </>
     );
 };
 
@@ -49,7 +56,7 @@ export interface ResourceDetailFullViewPresenterProps {
     imageUrl?: string;
     videoUrl?: string;
     audioUrl?: string;
-    contributions: string[];
+    contributions: ContributorWithId[];
     // TODO: Refactor the name property to eliminate this conditional type
     name: IMultilingualText | string;
     type: ResourceType;

--- a/libs/api-interfaces/src/lib/aggregate-views/view-models/base.view-model.interface.ts
+++ b/libs/api-interfaces/src/lib/aggregate-views/view-models/base.view-model.interface.ts
@@ -1,10 +1,15 @@
 import { HasId } from './has-id.interface';
 import { IMultilingualText } from './resources/common';
 
+export interface ContributorWithId {
+    id: string;
+    fullName: string;
+}
+
 export interface IBaseViewModel extends HasId {
     name: IMultilingualText;
 }
 
 export interface IBaseResourceViewModel extends IBaseViewModel {
-    contributions: string[];
+    contributions: ContributorWithId[];
 }

--- a/libs/api-interfaces/src/lib/aggregate-views/view-models/resources/song.view-model.interface.ts
+++ b/libs/api-interfaces/src/lib/aggregate-views/view-models/resources/song.view-model.interface.ts
@@ -1,7 +1,7 @@
-import { ContributorWithId, IBaseViewModel } from '../base.view-model.interface';
+import { IBaseResourceViewModel } from '../base.view-model.interface';
 import { IMultilingualText } from './common';
 
-export interface ISongViewModel extends IBaseViewModel {
+export interface ISongViewModel extends IBaseResourceViewModel {
     // We'll want to replace the following two props with a single `MultilingualText`
     title?: string;
 
@@ -13,6 +13,4 @@ export interface ISongViewModel extends IBaseViewModel {
     audioURL: string;
 
     lengthMilliseconds: number;
-
-    contributions: ContributorWithId[];
 }

--- a/libs/api-interfaces/src/lib/aggregate-views/view-models/resources/song.view-model.interface.ts
+++ b/libs/api-interfaces/src/lib/aggregate-views/view-models/resources/song.view-model.interface.ts
@@ -1,4 +1,4 @@
-import { IBaseViewModel } from '../base.view-model.interface';
+import { ContributorWithId, IBaseViewModel } from '../base.view-model.interface';
 import { IMultilingualText } from './common';
 
 export interface ISongViewModel extends IBaseViewModel {
@@ -14,5 +14,5 @@ export interface ISongViewModel extends IBaseViewModel {
 
     lengthMilliseconds: number;
 
-    contributions: string[];
+    contributions: ContributorWithId[];
 }


### PR DESCRIPTION
I've updated the term entity and command and also added the contributor id for the key and testid in the `ContributionsPresenter`.  See what you think.